### PR TITLE
Cleanup linkify regex patterns (efficiency)

### DIFF
--- a/app/js/linkify.js
+++ b/app/js/linkify.js
@@ -1,14 +1,14 @@
 import anchorme from 'anchorme';
 
 const IMAGE_HOSTING_REGEX = {
-  imgur: /(http(s)?:\/\/)?(i\.)?imgur\.com\/\w+\.(jpg|png)/i,
-  framapic: /(http(s)?:\/\/)?(www\.)?framapic\.org\/(random\?i=)?\w+\/\w+(\.(jpg|jpeg|png))?/i,
-  westnordost: /https:\/\/westnordost\.de\/p\/[0-9]+\.jpg/i,
-  wikimedia: /http(?:s)?:\/\/upload\.wikimedia\.org\/wikipedia\/(.+?)\/(?:thumb\/)?(\w\/\w\w)\/(.+?\.(?:jpg|jpeg|png))(?:\/.+?\.(?:jpg|jpeg|png))?/i,
-  commons: /http(?:s)?:\/\/commons\.wikimedia\.org\/wiki\/File:(.+?\.(?:jpg|jpeg|png|svg))/i,
-  openstreetmap: /http(?:s)?:\/\/wiki\.openstreetmap\.org\/wiki\/File:(.+?\.(?:jpg|jpeg|png|svg))/i,
-  mapillary: /http(?:s)?:\/\/(?:www\.)?mapillary\.com\/map\/im\/(\w+)/i,
-  all: /(http(s)?:\/\/)?(www\.)?.+\.(jpg|jpeg|png)/i
+  imgur: /(?:https?:\/\/)?(?:i\.)?imgur\.com\/\w+\.(?:jpe?g|png|webp)/i,
+  framapic: /(?:https?:\/\/)?(?:www\.)?framapic\.org\/(?:random\?i=)?\w+\/\w+(?:\.(?:jpe?g|png|webp))?/i,
+  westnordost: /(?:https?:\/\/)?(?:www\.)?westnordost\.de\/p\/[0-9]+\.(?:jpe?g|webp)/i,
+  wikimedia: /(?:https?:\/\/)?upload\.wikimedia\.org\/wikipedia\/(?:.+?)\/(?:thumb\/)?(?:\w\/\w\w)\/(?:.+?\.(?:jpe?g|png|webp))(?:\/.+?\.(?:jpe?g|png|webp))?/i,
+  commons: /(?:https?:\/\/)?commons\.wikimedia\.org\/wiki\/File:(?:.+?\.(?:jpe?g|png|svg|webp))/i,
+  openstreetmap: /(?:https?:\/\/)?wiki\.openstreetmap\.org\/wiki\/File:(?:.+?\.(?:jpe?g|png|svg|webp))/i,
+  mapillary: /(?:https?:\/\/)?(?:www\.)?mapillary\.com\/map\/im\/(?:\w+)/i,
+  all: /(?:https?:\/\/)?(?:www\.)?[0-9a-zA-Z%\/@\-\_\;\.\&\+\=]+\.(?:jpe?g|png|webp)/i
 };
 
 const IMAGE_HOSTING_ADDITIONAL_FORMATTING = {


### PR DESCRIPTION
Inspired by ENT8R/NotesReview#65:
* Avoid groups being capture-groups (memory-usage)
* more compact file-extension matching (especially similar extensions)
* replace `.+` with more specific URL-only set
* match more possible variations (robustness & future-proofing)